### PR TITLE
Disable requirement of ACL groups on add form

### DIFF
--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -935,8 +935,6 @@ if (!$oreon->user->admin && $o == "a") {
         'multiple' => true
     );
     $form->addElement('select2', 'acl_groups', _("ACL Resource Groups"), array(), $attrAclgroups);
-    $form->addRule('acl_groups', _("Mandatory field for ACL purpose."), 'required');
-    
 }
 
 /*


### PR DESCRIPTION

Hello,

When you want to add a host with a no admin account, the option ACL groups is mandatory.
This option is useful but not mandatory in all case. For example if you have ACL groups setup with all hostgroups/all hosts option.

Thanks.